### PR TITLE
Fixes /dev/ceton under ArchLinux, not sure for other Distros.

### DIFF
--- a/98-ctn91xx.rules
+++ b/98-ctn91xx.rules
@@ -1,1 +1,1 @@
-KERNEL=="ctn91xx_*",MODE="0666",OWNER="root",GROUP="root" SYMLINK+="ceton/%k"
+KERNEL=="ctn91xx_*", SYMLINK+="/ceton/%k", MODE="0666",OWNER="root",GROUP="root"


### PR DESCRIPTION
Using this lets /dev/ceton get symlink populated under ArchLinux
